### PR TITLE
Show token number in parser error listing

### DIFF
--- a/decompyle3/scanners/tok.py
+++ b/decompyle3/scanners/tok.py
@@ -117,12 +117,19 @@ class Token:
     def __str__(self) -> str:
         return self.format(line_prefix="")
 
-    def format(self, line_prefix="") -> str:
-        prefix = (
-            "\n%s%4d  " % (line_prefix, self.linestart)
-            if self.linestart
-            else (" " * (6 + len(line_prefix)))
-        )
+    def format(self, line_prefix="", token_num=None) -> str:
+        if token_num is not None:
+            prefix = (
+                "\n(%03d)%s L.%4d  " % (token_num, line_prefix, self.linestart)
+                if self.linestart
+                else ("(%03d)%s" % (token_num, " " * (9 + len(line_prefix))))
+            )
+        else:
+            prefix = (
+                "\n%s L.%4d  " % (line_prefix, self.linestart)
+                if self.linestart
+                else (" " * (9 + len(line_prefix)))
+            )
         offset_opname = "%8s  %-17s" % (self.offset, self.kind)
 
         if not self.has_arg:

--- a/decompyle3/semantics/parser_error.py
+++ b/decompyle3/semantics/parser_error.py
@@ -13,13 +13,15 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import decompyle3.parsers.main as python_parser
+
+
 class ParserError(python_parser.ParserError):
     def __init__(self, error, tokens):
-        self.error = error # previous exception
+        self.error = error  # previous exception
         self.tokens = tokens
 
     def __str__(self):
-        lines = ['--- This code section failed: ---']
-        lines.extend([str(i) for i in self.tokens])
-        lines.extend( ['', str(self.error)] )
-        return '\n'.join(lines)
+        lines = ["--- This code section failed: ---"]
+        lines.extend([t.format(token_num=i + 1) for i, t in enumerate(self.tokens)])
+        lines.extend(["", str(self.error)])
+        return "\n".join(lines)

--- a/pytest/test_token.py
+++ b/pytest/test_token.py
@@ -4,7 +4,7 @@ from decompyle3.scanners.tok import Token
 def test_token():
     # Test token formatting of: LOAD_CONST None
     t = Token("LOAD_CONST", offset=0, attr=None, pattr=None, has_arg=True)
-    expect = "             0  LOAD_CONST               None"
+    expect = "                0  LOAD_CONST               None"
     # print(t.format())
     assert t
     assert t.format() == expect
@@ -16,8 +16,12 @@ def test_token():
     # Make sure formatting of: LOAD_CONST False. We assume False is the 0th index
     # of co_consts.
     t = Token("LOAD_CONST", offset=1, attr=False, pattr=False, has_arg=True)
-    expect = "             1  LOAD_CONST               False"
+    expect = "                1  LOAD_CONST               False"
     assert t.format() == expect, t.format()
+
+    # Make sure formatting of: LOAD_CONST False. We assume False is the 0th index
+    expect = "(005)                1  LOAD_CONST               False"
+    assert t.format(token_num=5) == expect, t.format(token_num=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This can also go in python-uncompyle6. 

In debugging grammar errors, (`-g`) the token number is displayed (since that's what the parser knows). 

So when there is a parse error showing token numbers, in addition to line numbers and offsets, is helpful.