### PR TITLE
Wrongly denying the start opcode when there is an error raised

### DIFF
--- a/decompyle3/parsers/parse_heads.py
+++ b/decompyle3/parsers/parse_heads.py
@@ -199,7 +199,7 @@ class PythonBaseParser(GenericASTBuilder):
             if instructions[finish].linestart:
                 break
             pass
-        if start > 0:
+        if start >= 0:
             err_token = instructions[index]
             print("Instruction context:")
             for i in range(start, finish):


### PR DESCRIPTION
I'm not sure if I understand the code correctly but to me, it looks like `0` should also be allowed since we're using `-1` as an invalid start opcode index.