### PR TITLE
Add support for debug f-string

### DIFF
--- a/decompyle3/parsers/p38/full_custom.py
+++ b/decompyle3/parsers/p38/full_custom.py
@@ -395,27 +395,16 @@ class Python38FullCustom(Python38LambdaCustom, PythonBaseParser):
                     """
                 self.addRule(rules_str, nop_func)
 
-            elif opname == "BUILD_STRING_2":
-                self.addRule(
-                    """
-                      expr                  ::= formatted_value_debug
-                      formatted_value_debug ::= LOAD_STR formatted_value2 BUILD_STRING_2
-                      formatted_value_debug ::= LOAD_STR formatted_value1 BUILD_STRING_2
-                    """,
-                    nop_func,
+            elif opname.startswith("BUILD_STRING"):
+                v = token.attr
+                rules_str = """
+                    expr                  ::= formatted_value_debug
+                    formatted_value_debug ::= %s BUILD_STRING_%d
+                """ % (
+                    "expr " * (v),
+                    v,
                 )
-                custom_ops_processed.add(opname)
-
-            elif opname == "BUILD_STRING_3":
-                self.addRule(
-                    """
-                      expr                  ::= formatted_value_debug
-                      formatted_value_debug ::= LOAD_STR formatted_value2 LOAD_STR BUILD_STRING_3
-                      formatted_value_debug ::= LOAD_STR formatted_value1 LOAD_STR BUILD_STRING_3
-                    """,
-                    nop_func,
-                )
-                custom_ops_processed.add(opname)
+                self.addRule(rules_str, nop_func)
 
             elif opname in frozenset(
                 (

--- a/decompyle3/semantics/customize38.py
+++ b/decompyle3/semantics/customize38.py
@@ -315,7 +315,7 @@ def customize_for_version38(self, version):
             assert expr == "expr"
             child = expr[0]
             if child.kind == "formatted_value2":
-                fmt = child[1][0].attr
+                fmt = ":" + strip_quotes(self.traverse(child[1]))
             elif child.kind == "formatted_value1":
                 attr = child[1].attr
                 if attr & 4:
@@ -339,10 +339,6 @@ def customize_for_version38(self, version):
                 # Merge fragments "varname=" and "{varname:fmt}" into "{varname=:fmt}"
                 if fmt == "!r":
                     fmt = ""  # ignore the default !r format
-                elif fmt == "!s":
-                    pass
-                else:
-                    fmt = f":{fmt}"
                 prefix = fragments[-1][:-len(suffix)]
                 debug_fmt = f"{prefix}{{{varname}={fmt}}}"
                 fragments = fragments[:-1] + [debug_fmt]

--- a/decompyle3/semantics/customize38.py
+++ b/decompyle3/semantics/customize38.py
@@ -309,7 +309,7 @@ def customize_for_version38(self, version):
         # Collect all expressions that we're formatting one by one
         # Fragments is a list of parsed expressions, like ['a', '{a=}', 'b']
         # Caveat: python merges strings on bytecode level, so for example
-        # f"user setting: {user=}" becomes f"settings: user={user!r}".
+        # f"user setting: {user=}" becomes f"setting: user={user!r}".
         fragments = []
         for expr in node[:-1]:
             assert expr == "expr"


### PR DESCRIPTION
I have a feeling that you won't like it @rocky, but...

I've added support for debug f-strings by moving the complexity to post-processing. The code now "just" parses debug f-strings like normal f-strings, and looks for patterns of `XYZ={XYZ!r}` (and similar). I did this because I found the previous version quite buggy - for example it didn't support  `f'a{a=}b'`, `f'{abc=}{a}'`, `f'{abc=}a{a}'`, etc. To support arbitrary number of expressions in f-string it had to be generalised anyway (I think).

Another problem was that python combines string literals, so for example `a{a=}` will be compiled to `LOAD_STR aa=` and `LOAD_VALUE a`. Again, i've handled that during post-processing in semantic action.

Finally, if that approach is acceptable, I think "normal" and debug f-strings should be unified. Currently `f'{f}{g}{abc=}{a}{b}{c}{d}{e}'` is parsed using the "normal" fstring grammar, and because of this it decompiles to `abc={abc!r}` instead of `{abc=}` - not wrong, but suboptimal.

I'm happy to clean up this code and fix the rough edges, but submitting PR for (initial) review in case my approach is completely wrong and it should be done in some completely different way.

Fixes #105.

**edit** oh, and one more thing - I didn't find `test_debug_conversion` method in `test_fstring.py`, and `3.8-fstring-debug-attribute` seems to be entirely merged into master. Is #105's description correct?