### PR TITLE
Add a newline to decompiled files

### DIFF
--- a/decompyle3/main.py
+++ b/decompyle3/main.py
@@ -164,6 +164,7 @@ def decompile(
                 compile_mode=compile_mode,
             )
             pass
+        real_out.write("\n")
         return deparsed
     except pysource.SourceWalkerError as e:
         # deparsing failed


### PR DESCRIPTION
This solves #44 in the simplest way possible.

The other way to solve this issue is to add a "\n" to the grammar itself. For example we can add a semantic rule for `single_start` and emit a single newline after parsing. At least I think this would work. But, since this is a cosmetic improvement only, and I'm not certain using grammar for that makes more sense, I've opted for a simpler approach.

To reproduce, you can do for example:

Before:
```
$ decompyle3 /tmp/ss/__pycache__/c.cpython-38.pyc -o /tmp/; cat /tmp/c.cpython-38.py | xxd | tail -n1
/tmp/ss/__pycache__/c.cpython-38.pyc --
# Successfully decompiled all files
00000110: 7465 7374 2729                           test')
```

After:
```
$ decompyle3 /tmp/ss/__pycache__/c.cpython-38.pyc -o /tmp/; cat /tmp/c.cpython-38.py | xxd | tail -n1
/tmp/ss/__pycache__/c.cpython-38.pyc --
# Successfully decompiled all files
00000110: 7465 7374 2729 0a                        test').
```

Fixes #44